### PR TITLE
[figma]:update to 1.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adui-icon",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "A package for storing adui svg icon data",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fix: warning-outlined 修改名字为 warning-circle-outlined